### PR TITLE
Fix audit log generation and update logic in comment submissions

### DIFF
--- a/src/main/java/com/codelogium/ticketing/service/CommentServiceImp.java
+++ b/src/main/java/com/codelogium/ticketing/service/CommentServiceImp.java
@@ -43,9 +43,9 @@ public class CommentServiceImp implements CommentService {
         newComment.setCreatedAt(Instant.now());
         Comment createdComment = commentRepository.save(newComment);
 
-        // Log ticket creation
+        // Log comment creation (let JPA generate the audit log id)
         auditLogRepository.save(new AuditLog(
-            retrieveTicket.getId(),
+                null,
                 ticketId,
                 createdComment.getId(),
                 userId,
@@ -70,25 +70,24 @@ public class CommentServiceImp implements CommentService {
         Comment retrievedComment = unwrapComment(commentId,
                 commentRepository.findByIdAndTicketIdAndAuthorId(commentId, ticketId, userId));
         // Store old content value before making changes
-        String content = retrievedComment.getContent();
+        String oldContent = retrievedComment.getContent();
         updateIfNotNull(retrievedComment::setContent, newComment.getContent());
         updateIfNotNull(retrievedComment::setTicket, newComment.getTicket());
 
-        // if the user changed the content of the comment, update the timestamp
-        Comment savedComment = new Comment();
-        if (newComment.getContent().equals(retrievedComment.getContent())) {
+        // if the user changed the content of the comment, update the timestamp and log
+        Comment savedComment = retrievedComment;
+        if (newComment.getContent() != null && !newComment.getContent().equals(oldContent)) {
             updateIfNotNull(retrievedComment::setCreatedAt, Instant.now());
             // attempts to save comment
             savedComment = commentRepository.save(retrievedComment);
 
-            // Log ticket creation
             auditLogRepository.save(new AuditLog(
                     null,
                     ticket.getId(),
                     retrievedComment.getId(),
                     userId,
                     "COMMENT_UPDATED",
-                    content,
+                    oldContent,
                     retrievedComment.getContent(),
                     Instant.now()));
 

--- a/src/main/java/com/codelogium/ticketing/web/TicketController.java
+++ b/src/main/java/com/codelogium/ticketing/web/TicketController.java
@@ -119,8 +119,8 @@ public class TicketController {
     @Operation(summary = "Audit Tickets Logs", description = "Retrieves audit logs of a ticket")
     @PreAuthorize("hasAuthority('IT_SUPPORT')")
     @GetMapping("/{ticketId}/audit-logs")
-    public ResponseEntity<List<AuditLog>> retrieveAuditLogs(@PathVariable Long ticketId) {
-        return ResponseEntity.ok(ticketService.retrieveAuditLogs(ticketId, ticketId));
+    public ResponseEntity<List<AuditLog>> retrieveAuditLogs(@PathVariable Long userId, @PathVariable Long ticketId) {
+        return ResponseEntity.ok(ticketService.retrieveAuditLogs(ticketId, userId));
     }
 
     @ApiResponses(value = {


### PR DESCRIPTION
This PR addresses issues in the comment creation and update logic, specifically concerning the audit logging functionality. The `createComment` method was updated to correctly log when a comment is created without referencing a ticket ID in the audit log, now passing null for the audit log ID. Additionally, the `updateComment` method was modified to ensure that if the comment content is updated, it now updates the timestamp and logs both old and new content correctly in the audit log. Finally, the `retrieveAuditLogs` endpoint was adjusted to correctly accept `userId` as a parameter before fetching the audit logs.

---

> This pull request was co-created with Cosine Genie

Original Task: [it-support-ticket-system/xhplc3c7qdah](https://cosine.wtf/demo-staging/it-support-ticket-system/task/xhplc3c7qdah)
Author: Pandelis Zembashis
